### PR TITLE
Bug : check set Test result values properlu

### DIFF
--- a/TestingHelperTest/public/ModuleHelperTest.ps1
+++ b/TestingHelperTest/public/ModuleHelperTest.ps1
@@ -31,6 +31,23 @@ function TestingHelperTest_AddModuleHeaderToTest{
     Assert-AreEqual -Expected (GetExpectedHeader) -Presented $infoVar[0]
 }
 
+function TestingHelperTest_TestModulelocalPSD1_ResultObject{
+
+    New-TT_Modulev2 -Name "ModuleName" -Description "description of the Module" -Version "9.9.9"
+
+    $test = "ModuleName" | Join-Path -ChildPath "test.ps1" | Resolve-Path
+
+    # Add prefix to call the script calling commandlet to call the tested version of TestingHelper
+    (Get-Content -Path $test) -replace "Test-ModulelocalPSD1","Test-TT_ModulelocalPSD1" | Set-Content -Path $test
+
+    # Run the test.ps1 
+    $result = & $test @InfoParameters
+
+    Assert-AreEqual -Expected "ModuleName" -Presented $result.Name
+    Assert-AreEqual -Expected "ModuleNameTest" -Presented $result.TestModule
+    Assert-AreEqual -Expected "ModuleNameTest_*" -Presented $result.TestsName
+}
+
 # Testing TestingHelperTest private function Get-ModuleHandle
 function TestingHelperTest_GetModuleHandle {
     $localPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent

--- a/public/TestingHelper.ps1
+++ b/public/TestingHelper.ps1
@@ -299,7 +299,7 @@ function Test-ModulelocalPSD1 {
             $time = ($start | New-TimeSpan ).ToString("hh\:mm\:ss\:FFFF")
             
             # Add extra info to result
-            $result | Add-Member -NotePropertyName "Name" -NotePropertyValue $Name
+            $result | Add-Member -NotePropertyName "Name" -NotePropertyValue $manifest.Name
             $result | Add-Member -NotePropertyName "TestModule" -NotePropertyValue $TestingModuleName
             $result | Add-Member -NotePropertyName "TestsName" -NotePropertyValue $functionsTestName
             $result | Add-Member -NotePropertyName "Tests" -NotePropertyValue $functionsTest.Length


### PR DESCRIPTION
```
    Assert-AreEqual -Expected "ModuleName" -Presented $result.Name
    Assert-AreEqual -Expected "ModuleNameTest" -Presented $result.TestModule
    Assert-AreEqual -Expected "ModuleNameTest_*" -Presented $result.TestsName
```