### PR TITLE
Allow New-ModuleV3 on existing folders

### DIFF
--- a/TestingHelperTest/public/New-ModuleV3-Add-ModuleV3.Tests.ps1
+++ b/TestingHelperTest/public/New-ModuleV3-Add-ModuleV3.Tests.ps1
@@ -37,6 +37,30 @@ function TestingHelperTest_NewModuleV3_AddModule_FailCall_NewModuleManifest {
 
 }
 
+function TestingHelperTest_NewModuleV3_AddModule_FolderExists {
+
+    $moduleName = "MyModule"
+
+    New-TestingFolder -Name $moduleName
+
+    $result = Add-TT_ModuleV3 -Name $moduleName
+
+    Assert-AddModuleV3  -Path $result
+}
+
+
+function TestingHelperTest_NewModuleV3_AddModule_ModuleExistInFolder {
+
+    $moduleName = "MyModule"
+
+    $result = Add-TT_ModuleV3 -Name $moduleName
+
+    $result = Add-TT_ModuleV3 -Name $moduleName @ErrorParameters
+
+    Assert-IsNull -Object $result
+    Assert-Contains -Expected "Module already exists." -Presented ($errorVar.Exception.Message)
+}
+
 function TestingHelperTest_NewModuleV3_AddModule_DefaultManifest {
 
     $moduleName = "MyModule"

--- a/private/New-ModuleV3.Helper.ps1
+++ b/private/New-ModuleV3.Helper.ps1
@@ -77,8 +77,8 @@ function New-ModuleFolder{
                 }
                 # Converting to Provider path
                 return $Path | Convert-Path
-            } 
-            
+            }
+
             # Folder exists. Check if the psd1 file exists
             $psd1Path = ($Path | Join-Path -ChildPath "$($Path | Split-Path -LeafBase).psd1")
             if($psd1Path | Test-Path){
@@ -88,12 +88,11 @@ function New-ModuleFolder{
 
             return $Path | Convert-Path
 
-        } 
+        }
         catch {
             Write-Error -Message "Failed to add path."
             return $null
         }
     }
-
 }
 

--- a/private/New-ModuleV3.Helper.ps1
+++ b/private/New-ModuleV3.Helper.ps1
@@ -61,7 +61,7 @@ function Get-TestModuleName {
     return $name
 } 
 
-function New-Folder{
+function New-ModuleFolder{
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory,ValueFromPipeline)][string]$Path
@@ -71,17 +71,23 @@ function New-Folder{
 
         try {
             #test if path exists
-            if($Path | Test-Path){
-                Write-Error "Path already exists."
-                return $null
-            } else {
+            if(!($Path | Test-Path)){
                 if ($PSCmdlet.ShouldProcess($Path, "New-Item -ItemType Directory")) {
                     $null = New-Item -ItemType Directory -Path $Path
                 }
-                
                 # Converting to Provider path
                 return $Path | Convert-Path
+            } 
+            
+            # Folder exists. Check if the psd1 file exists
+            $psd1Path = ($Path | Join-Path -ChildPath "$($Path | Split-Path -LeafBase).psd1")
+            if($psd1Path | Test-Path){
+                Write-Error -Message "Module already exists."
+                return $null
             }
+
+            return $Path | Convert-Path
+
         } 
         catch {
             Write-Error -Message "Failed to add path."

--- a/public/Add-ModuleV3.ps1
+++ b/public/Add-ModuleV3.ps1
@@ -22,7 +22,7 @@ function Add-ModuleV3 {
 
     # Create the module folder. Fail if exists
     # This will filter if Path already exist to avoid overwriting an existing module
-    $modulePath = $modulePathString | New-Folder
+    $modulePath = $modulePathString | New-ModuleFolder
     if( !$modulePath ){ return $null }
 
     $moduleName = Get-ModuleName -Path $modulePath


### PR DESCRIPTION
Actually we fail when calling New-ModuleV3 to create a folder for which the folder exists.

We shall allow module to be created on a folder that exist if their is no module inside.